### PR TITLE
Get actual block states

### DIFF
--- a/src/main/java/subaraki/exsartagine/block/KitchenwareBlock.java
+++ b/src/main/java/subaraki/exsartagine/block/KitchenwareBlock.java
@@ -27,7 +27,7 @@ public abstract class KitchenwareBlock extends Block {
 
     @Override
     public boolean canPlaceBlockAt(World world, BlockPos pos) {
-        return ModRecipes.isPlaceable(world.getBlockState(pos.down()));
+        return ModRecipes.isPlaceable(world.getBlockState(pos.down()).getActualState(world, pos.down()));
     }
 
     @Override

--- a/src/main/java/subaraki/exsartagine/tileentity/util/KitchenwareBlockEntity.java
+++ b/src/main/java/subaraki/exsartagine/tileentity/util/KitchenwareBlockEntity.java
@@ -17,7 +17,7 @@ public abstract class KitchenwareBlockEntity extends TileEntity {
 
     //check if the block below is hot
     public final boolean activeHeatSourceBelow() {
-        return ModRecipes.isHeatSource(world.getBlockState(pos.down()));
+        return ModRecipes.isHeatSource(world.getBlockState(pos.down()).getActualState(world, pos.down()));
     }
 
     public abstract IItemHandler getEntireItemInventory();


### PR DESCRIPTION
Get actual block states when checking placement and heating. Allows these methods to work with blocks that don't save needed state properties to meta.