### PR TITLE
Add integration for the Immersive Engineering external heater

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,7 @@ dependencies {
     // http://www.gradle.org/docs/current/userguide/dependency_management.html
 
     deobfCompile 'CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.1.17.536'
+    deobfCompile "blusunrize:ImmersiveEngineering:0.12-92-559"
 }
 
 processResources {

--- a/src/main/java/subaraki/exsartagine/ExSartagine.java
+++ b/src/main/java/subaraki/exsartagine/ExSartagine.java
@@ -15,7 +15,6 @@ import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fml.client.registry.ClientRegistry;
-import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
@@ -29,7 +28,7 @@ import subaraki.exsartagine.init.ExSartagineBlocks;
 import subaraki.exsartagine.init.ExSartagineItems;
 import subaraki.exsartagine.init.ModBlockEntities;
 import subaraki.exsartagine.init.ModSounds;
-import subaraki.exsartagine.integration.ImmersiveEngineering;
+import subaraki.exsartagine.integration.Integration;
 import subaraki.exsartagine.network.PacketHandler;
 import subaraki.exsartagine.recipe.ModRecipes;
 import subaraki.exsartagine.recipe.WokRecipe;
@@ -106,6 +105,6 @@ public class ExSartagine {
     public void postInit(FMLPostInitializationEvent e) {
         Oredict.addToOreDict();
         ModRecipes.cacheWokInputs();
-        if(Loader.isModLoaded("immersiveengineering")){ImmersiveEngineering.registerHeatableAdapters();}
+        Integration.postInit();
     }
 }

--- a/src/main/java/subaraki/exsartagine/ExSartagine.java
+++ b/src/main/java/subaraki/exsartagine/ExSartagine.java
@@ -15,6 +15,7 @@ import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fml.client.registry.ClientRegistry;
+import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
@@ -28,6 +29,7 @@ import subaraki.exsartagine.init.ExSartagineBlocks;
 import subaraki.exsartagine.init.ExSartagineItems;
 import subaraki.exsartagine.init.ModBlockEntities;
 import subaraki.exsartagine.init.ModSounds;
+import subaraki.exsartagine.integration.ImmersiveEngineering;
 import subaraki.exsartagine.network.PacketHandler;
 import subaraki.exsartagine.recipe.ModRecipes;
 import subaraki.exsartagine.recipe.WokRecipe;
@@ -104,5 +106,6 @@ public class ExSartagine {
     public void postInit(FMLPostInitializationEvent e) {
         Oredict.addToOreDict();
         ModRecipes.cacheWokInputs();
+        if(Loader.isModLoaded("immersiveengineering")){ImmersiveEngineering.registerHandlers();}
     }
 }

--- a/src/main/java/subaraki/exsartagine/ExSartagine.java
+++ b/src/main/java/subaraki/exsartagine/ExSartagine.java
@@ -106,6 +106,6 @@ public class ExSartagine {
     public void postInit(FMLPostInitializationEvent e) {
         Oredict.addToOreDict();
         ModRecipes.cacheWokInputs();
-        if(Loader.isModLoaded("immersiveengineering")){ImmersiveEngineering.registerHandlers();}
+        if(Loader.isModLoaded("immersiveengineering")){ImmersiveEngineering.registerHeatableAdapters();}
     }
 }

--- a/src/main/java/subaraki/exsartagine/block/BlockRange.java
+++ b/src/main/java/subaraki/exsartagine/block/BlockRange.java
@@ -170,7 +170,7 @@ public class BlockRange extends Block {
     @SideOnly(Side.CLIENT)
     public void randomDisplayTick(IBlockState stateIn, World worldIn, BlockPos pos, Random rand) {
         if (worldIn.getTileEntity(pos) instanceof TileEntityRange) {
-            if (((TileEntityRange) worldIn.getTileEntity(pos)).isFueled()) {
+            if (((TileEntityRange) worldIn.getTileEntity(pos)).isHeated()) {
                 if (hearth) {
                     vanillaFurnaceParticles(stateIn, worldIn, pos, rand);
                 } else {

--- a/src/main/java/subaraki/exsartagine/gui/client/screen/GuiRange.java
+++ b/src/main/java/subaraki/exsartagine/gui/client/screen/GuiRange.java
@@ -41,7 +41,7 @@ public class GuiRange extends GuiContainer {
 
 		fade +=0.05f;
 		
-		if(range.isFueled())
+		if(range.isHeated())
 		{
 			GlStateManager.enableBlend();
 			GlStateManager.color(1f, 1f, 1f, (float)(Math.cos(Math.sin(fade))));

--- a/src/main/java/subaraki/exsartagine/integration/ImmersiveEngineering.java
+++ b/src/main/java/subaraki/exsartagine/integration/ImmersiveEngineering.java
@@ -12,22 +12,27 @@ import subaraki.exsartagine.tileentity.TileEntityRange;
 import subaraki.exsartagine.tileentity.util.KitchenwareBlockEntity;
 
 public class ImmersiveEngineering {
-    public static void registerHandlers(){
+    public static void registerHeatableAdapters(){
         ExternalHeaterHandler.registerHeatableAdapter(KitchenwareBlockEntity.class, new KitchenwareAdapter());
+        addPlaceableForHeater();
         ExternalHeaterHandler.registerHeatableAdapter(TileEntityRange.class, new RangeAdapter());
+    }
+
+    private static void addPlaceableForHeater(){
         ModRecipes.addPlaceable(IEContent.blockMetalDevice1, iBlockState -> (
-                iBlockState.getValue(PropertyEnum.create("type", BlockTypes_MetalDevice1.class))==BlockTypes_MetalDevice1.FURNACE_HEATER &&
-                        !iBlockState.getValue(IEProperties.MULTIBLOCKSLAVE) &&
-                        iBlockState.getValue(IEProperties.FACING_ALL) != EnumFacing.UP &&
-                        iBlockState.getValue(IEProperties.BOOLEANS[0])
+                iBlockState.getValue(PropertyEnum.create("type", BlockTypes_MetalDevice1.class))==BlockTypes_MetalDevice1.FURNACE_HEATER
+                        && !iBlockState.getValue(IEProperties.MULTIBLOCKSLAVE) //not part of multiblock
+                        && iBlockState.getValue(IEProperties.FACING_ALL) != EnumFacing.UP
+                        && iBlockState.getValue(IEProperties.BOOLEANS[0]) //active
         ),true, false);
         ModRecipes.addPlaceable(IEContent.blockMetalDevice1, iBlockState -> (
-                iBlockState.getValue(PropertyEnum.create("type", BlockTypes_MetalDevice1.class))==BlockTypes_MetalDevice1.FURNACE_HEATER &&
-                        !iBlockState.getValue(IEProperties.MULTIBLOCKSLAVE) &&
-                        iBlockState.getValue(IEProperties.FACING_ALL) != EnumFacing.UP &&
-                        !iBlockState.getValue(IEProperties.BOOLEANS[0])
+                iBlockState.getValue(PropertyEnum.create("type", BlockTypes_MetalDevice1.class))==BlockTypes_MetalDevice1.FURNACE_HEATER
+                        && !iBlockState.getValue(IEProperties.MULTIBLOCKSLAVE) //not part of multiblock
+                        && iBlockState.getValue(IEProperties.FACING_ALL) != EnumFacing.UP
+                        && !iBlockState.getValue(IEProperties.BOOLEANS[0]) //inactive
         ),false, false);
     }
+
     public static class KitchenwareAdapter extends ExternalHeaterHandler.HeatableAdapter<KitchenwareBlockEntity>{
         @Override
         public int doHeatTick(KitchenwareBlockEntity tileEntity, int energyAvailable, boolean redstone) {

--- a/src/main/java/subaraki/exsartagine/integration/ImmersiveEngineering.java
+++ b/src/main/java/subaraki/exsartagine/integration/ImmersiveEngineering.java
@@ -51,7 +51,6 @@ public class ImmersiveEngineering {
             if(redstone && energyAvailable >= consumption){
                 if(tileEntity.getFuelTimer()==0){tileEntity.setFuelTimer(1);}
                 tileEntity.setFuelTimer(tileEntity.getFuelTimer()+1);
-                tileEntity.setCooking(true);
                 return consumption;
             }
             return 0;

--- a/src/main/java/subaraki/exsartagine/integration/ImmersiveEngineering.java
+++ b/src/main/java/subaraki/exsartagine/integration/ImmersiveEngineering.java
@@ -37,7 +37,7 @@ public class ImmersiveEngineering {
         @Override
         public int doHeatTick(KitchenwareBlockEntity tileEntity, int energyAvailable, boolean redstone) {
             int consumption = Config.IEConfig.Machines.heater_consumption;
-            if(energyAvailable >= consumption){
+            if(redstone && energyAvailable >= consumption){
                 return consumption;
             }
             return 0;
@@ -48,7 +48,7 @@ public class ImmersiveEngineering {
         @Override
         public int doHeatTick(TileEntityRange tileEntity, int energyAvailable, boolean redstone) {
             int consumption = Config.IEConfig.Machines.heater_consumption;
-            if(!redstone && energyAvailable >= consumption){
+            if(redstone && energyAvailable >= consumption){
                 if(tileEntity.getFuelTimer()==0){tileEntity.setFuelTimer(1);}
                 tileEntity.setFuelTimer(tileEntity.getFuelTimer()+1);
                 tileEntity.setCooking(true);

--- a/src/main/java/subaraki/exsartagine/integration/ImmersiveEngineering.java
+++ b/src/main/java/subaraki/exsartagine/integration/ImmersiveEngineering.java
@@ -49,11 +49,11 @@ public class ImmersiveEngineering {
         public int doHeatTick(TileEntityRange tileEntity, int energyAvailable, boolean redstone) {
             int consumption = Config.IEConfig.Machines.heater_consumption;
             if(!redstone && energyAvailable >= consumption){
-                tileEntity.setFuelTimer(-1);
+                if(tileEntity.getFuelTimer()==0){tileEntity.setFuelTimer(1);}
+                tileEntity.setFuelTimer(tileEntity.getFuelTimer()+1);
                 tileEntity.setCooking(true);
                 return consumption;
             }
-            if(tileEntity.getFuelTimer()==-1){tileEntity.setFuelTimer(0);}
             return 0;
         }
     }

--- a/src/main/java/subaraki/exsartagine/integration/ImmersiveEngineering.java
+++ b/src/main/java/subaraki/exsartagine/integration/ImmersiveEngineering.java
@@ -8,11 +8,13 @@ import blusunrize.immersiveengineering.common.blocks.metal.BlockTypes_MetalDevic
 import net.minecraft.block.properties.PropertyEnum;
 import net.minecraft.util.EnumFacing;
 import subaraki.exsartagine.recipe.ModRecipes;
+import subaraki.exsartagine.tileentity.TileEntityRange;
 import subaraki.exsartagine.tileentity.util.KitchenwareBlockEntity;
 
 public class ImmersiveEngineering {
     public static void registerHandlers(){
         ExternalHeaterHandler.registerHeatableAdapter(KitchenwareBlockEntity.class, new KitchenwareAdapter());
+        ExternalHeaterHandler.registerHeatableAdapter(TileEntityRange.class, new RangeAdapter());
         ModRecipes.addPlaceable(IEContent.blockMetalDevice1, iBlockState -> (
                 iBlockState.getValue(PropertyEnum.create("type", BlockTypes_MetalDevice1.class))==BlockTypes_MetalDevice1.FURNACE_HEATER &&
                         !iBlockState.getValue(IEProperties.MULTIBLOCKSLAVE) &&
@@ -33,6 +35,20 @@ public class ImmersiveEngineering {
             if(energyAvailable >= consumption){
                 return consumption;
             }
+            return 0;
+        }
+    }
+
+    public static class RangeAdapter extends ExternalHeaterHandler.HeatableAdapter<TileEntityRange>{
+        @Override
+        public int doHeatTick(TileEntityRange tileEntity, int energyAvailable, boolean redstone) {
+            int consumption = Config.IEConfig.Machines.heater_consumption;
+            if(!redstone && energyAvailable >= consumption){
+                tileEntity.setFuelTimer(-1);
+                tileEntity.setCooking(true);
+                return consumption;
+            }
+            if(tileEntity.getFuelTimer()==-1){tileEntity.setFuelTimer(0);}
             return 0;
         }
     }

--- a/src/main/java/subaraki/exsartagine/integration/ImmersiveEngineering.java
+++ b/src/main/java/subaraki/exsartagine/integration/ImmersiveEngineering.java
@@ -1,0 +1,39 @@
+package subaraki.exsartagine.integration;
+
+import blusunrize.immersiveengineering.api.IEProperties;
+import blusunrize.immersiveengineering.api.tool.ExternalHeaterHandler;
+import blusunrize.immersiveengineering.common.Config;
+import blusunrize.immersiveengineering.common.IEContent;
+import blusunrize.immersiveengineering.common.blocks.metal.BlockTypes_MetalDevice1;
+import net.minecraft.block.properties.PropertyEnum;
+import net.minecraft.util.EnumFacing;
+import subaraki.exsartagine.recipe.ModRecipes;
+import subaraki.exsartagine.tileentity.util.KitchenwareBlockEntity;
+
+public class ImmersiveEngineering {
+    public static void registerHandlers(){
+        ExternalHeaterHandler.registerHeatableAdapter(KitchenwareBlockEntity.class, new KitchenwareAdapter());
+        ModRecipes.addPlaceable(IEContent.blockMetalDevice1, iBlockState -> (
+                iBlockState.getValue(PropertyEnum.create("type", BlockTypes_MetalDevice1.class))==BlockTypes_MetalDevice1.FURNACE_HEATER &&
+                        !iBlockState.getValue(IEProperties.MULTIBLOCKSLAVE) &&
+                        iBlockState.getValue(IEProperties.FACING_ALL) != EnumFacing.UP &&
+                        iBlockState.getValue(IEProperties.BOOLEANS[0])
+        ),true, false);
+        ModRecipes.addPlaceable(IEContent.blockMetalDevice1, iBlockState -> (
+                iBlockState.getValue(PropertyEnum.create("type", BlockTypes_MetalDevice1.class))==BlockTypes_MetalDevice1.FURNACE_HEATER &&
+                        !iBlockState.getValue(IEProperties.MULTIBLOCKSLAVE) &&
+                        iBlockState.getValue(IEProperties.FACING_ALL) != EnumFacing.UP &&
+                        !iBlockState.getValue(IEProperties.BOOLEANS[0])
+        ),false, false);
+    }
+    public static class KitchenwareAdapter extends ExternalHeaterHandler.HeatableAdapter<KitchenwareBlockEntity>{
+        @Override
+        public int doHeatTick(KitchenwareBlockEntity tileEntity, int energyAvailable, boolean redstone) {
+            int consumption = Config.IEConfig.Machines.heater_consumption;
+            if(energyAvailable >= consumption){
+                return consumption;
+            }
+            return 0;
+        }
+    }
+}

--- a/src/main/java/subaraki/exsartagine/integration/Integration.java
+++ b/src/main/java/subaraki/exsartagine/integration/Integration.java
@@ -1,0 +1,9 @@
+package subaraki.exsartagine.integration;
+
+import net.minecraftforge.fml.common.Loader;
+
+public class Integration {
+    public static void postInit(){
+        if(Loader.isModLoaded("immersiveengineering")){ImmersiveEngineering.registerHeatableAdapters();}
+    }
+}

--- a/src/main/java/subaraki/exsartagine/tileentity/TileEntityRange.java
+++ b/src/main/java/subaraki/exsartagine/tileentity/TileEntityRange.java
@@ -240,7 +240,10 @@ public class TileEntityRange extends TileEntity implements ITickable {
     public void setFuelTimer(int timer){
         fuelTimer = timer;
         if(maxFuelTimer==0){ maxFuelTimer=fuelTimer; }
-        if(timer>0 && !isHeated()){ setCooking(true); }
+        if(timer>0 && !isHeated()){
+            setCooking(true);
+            markDirty();
+        }
     }
 
         @Override

--- a/src/main/java/subaraki/exsartagine/tileentity/TileEntityRange.java
+++ b/src/main/java/subaraki/exsartagine/tileentity/TileEntityRange.java
@@ -238,7 +238,8 @@ public class TileEntityRange extends TileEntity implements ITickable {
     }
 
     public void setFuelTimer(int timer){
-        maxFuelTimer = fuelTimer = timer;
+        fuelTimer = timer;
+        if(maxFuelTimer==0){maxFuelTimer=fuelTimer;}
     }
 
         @Override

--- a/src/main/java/subaraki/exsartagine/tileentity/TileEntityRange.java
+++ b/src/main/java/subaraki/exsartagine/tileentity/TileEntityRange.java
@@ -84,7 +84,7 @@ public class TileEntityRange extends TileEntity implements ITickable {
         }
     }
 
-    public void setCooking(boolean cooking) {
+    private void setCooking(boolean cooking) {
         setRangeConnectionsCooking(cooking);
         IBlockState state = world.getBlockState(pos);
         IBlockState newState = state.withProperty(BlockRange.HEATED,cooking);
@@ -239,7 +239,8 @@ public class TileEntityRange extends TileEntity implements ITickable {
 
     public void setFuelTimer(int timer){
         fuelTimer = timer;
-        if(maxFuelTimer==0){maxFuelTimer=fuelTimer;}
+        if(maxFuelTimer==0){ maxFuelTimer=fuelTimer; }
+        if(timer>0 && !isHeated()){ setCooking(true); }
     }
 
         @Override

--- a/src/main/java/subaraki/exsartagine/tileentity/TileEntityRange.java
+++ b/src/main/java/subaraki/exsartagine/tileentity/TileEntityRange.java
@@ -84,7 +84,7 @@ public class TileEntityRange extends TileEntity implements ITickable {
         }
     }
 
-    private void setCooking(boolean cooking) {
+    public void setCooking(boolean cooking) {
         setRangeConnectionsCooking(cooking);
         IBlockState state = world.getBlockState(pos);
         IBlockState newState = state.withProperty(BlockRange.HEATED,cooking);
@@ -235,6 +235,10 @@ public class TileEntityRange extends TileEntity implements ITickable {
                 rangeExtension.setParentRange(pos);
             }
         }
+    }
+
+    public void setFuelTimer(int timer){
+        maxFuelTimer = fuelTimer = timer;
     }
 
         @Override

--- a/src/main/java/subaraki/exsartagine/tileentity/TileEntityRange.java
+++ b/src/main/java/subaraki/exsartagine/tileentity/TileEntityRange.java
@@ -97,7 +97,7 @@ public class TileEntityRange extends TileEntity implements ITickable {
 
 
     public boolean isFueled() {
-        return fuelTimer > 0;
+        return fuelTimer > 0 || fuelTimer == -1;
     }
 
     public int getFuelTimer() {

--- a/src/main/java/subaraki/exsartagine/tileentity/TileEntityRange.java
+++ b/src/main/java/subaraki/exsartagine/tileentity/TileEntityRange.java
@@ -97,7 +97,7 @@ public class TileEntityRange extends TileEntity implements ITickable {
 
 
     public boolean isFueled() {
-        return fuelTimer > 0 || fuelTimer == -1;
+        return fuelTimer > 0;
     }
 
     public int getFuelTimer() {


### PR DESCRIPTION
Allows the external heater to heat ranges and kitchenware. Not possible with CraftTweaker alone because of the need for new IE HeatableAdapters.

Not a perfect implementation:
- ~~Particles and~~ GUI for Stove/Hearth not displaying properly because the client is reading the TileEntity as unfueled ~~for some reason~~
- Required some minor changes to TileEntityRange to make fuelTimer and cooking values accessible to adapter